### PR TITLE
Use dockerhub as cache for dockerimages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 language: cpp
 sudo: required
 services:
-    - docker
+  - docker
 dist: trusty
 os: linux
 install: skip
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y install docker-ce
+  - docker --version
 script:
-    - docker build . -t capstone
-    - docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
+  - docker pull kairosautomotive/carla-brain:latest 
+  - docker build . --cache-from kairosautomotive/carla-brain:latest -t capstone
+  - docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
 notifications:
-    email:
-        on_success: change
-        on_failure: always
+  email:
+      on_success: change
+      on_failure: always
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,22 +11,22 @@ RUN apt-get update
 # setup rosdep
 RUN sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
 RUN rosdep update
-RUN apt-get install -y ros-$ROS_DISTRO-dbw-mkz
+RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-dbw-mkz
 RUN apt-get upgrade -y
 # end installing Dataspeed DBW
 
-# install python packages
-RUN apt-get install -y python-pip
-COPY requirements.txt ./requirements.txt
-RUN pip install -r requirements.txt
-
 # install required ros dependencies
-RUN apt-get install -y ros-$ROS_DISTRO-cv-bridge
-RUN apt-get install -y ros-$ROS_DISTRO-pcl-ros
-RUN apt-get install -y ros-$ROS_DISTRO-image-proc
+RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-cv-bridge
+RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-pcl-ros
+RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-image-proc
 
 # socket io
-RUN apt-get install -y netbase
+RUN apt-get install -y --no-install-recommends netbase
+
+# install python packages
+RUN apt-get install -y --no-install-recommends python-pip
+RUN pip install --upgrade "pip==9.0.1"
+RUN pip install "Flask==0.12.2" "attrdict==2.0.0" "eventlet==0.21.0" "python-socketio==1.8.1" "numpy==1.13.3" "Pillow==4.3.0" "scipy==0.19.1" "keras==1.2.0" "tensorflow==1.0.0"
 
 RUN mkdir /capstone
 VOLUME ["/capstone"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Self Driving Car Engineer Nanodegree -- Capstone project
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/79ddbbe506054e43859247d9fd0b11b5)](https://www.codacy.com/app/Kairos-Automotive/carla-brain?utm_source=github.com&utm_medium=referral&utm_content=Kairos-Automotive/carla-brain&utm_campaign=badger)
-[![Build Status](https://travis-ci.org/Kairos-Automotive/carla-brain.svg?branch=master)](https://travis-ci.org/Kairos-Automotive/carla-brain)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/79ddbbe506054e43859247d9fd0b11b5)](https://www.codacy.com/app/Kairos-Automotive/carla-brain?utm_source=github.com&utm_medium=referral&utm_content=Kairos-Automotive/carla-brain&utm_campaign=badger) 
+[![Build Status](https://travis-ci.org/Kairos-AutomotAive/carla-braAin.svg?branch=master)](https://travis-ci.org/Kairos-Automotive/carla-brain) 
+[![Docker Status](https://dockerbuildbadges.quelltext.eu/status.svg?organization=kairosautomotive&repository=carla-brain)](https://hub.docker.com/r/kairosautomotive/carla-brain/) 
 
 This is the project repo for the final project of the Udacity
 Self-Driving Car Nanodegree: Programming a Real Self-Driving Car.
-
 
 ## Team Members
 
@@ -43,12 +43,17 @@ The Udacity provided virtual machine has ROS and Dataspeed DBW already installed
 
 Build the docker container
 ```bash
-docker build . -t capstone
+docker build . -t kairosautomotive/carla-brain:latest
+```
+
+or pull the latest docker container from dockerhub
+```bash
+docker pull kairosautomotive/carla-brain:latest
 ```
 
 Run the docker file
 ```bash
-docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it capstone
+docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it kairosautomotive/carla-brain
 ```
 
 ### Simulator


### PR DESCRIPTION
Building the docker image using travis
take some time and lead several times to
broken builds as of timed out downloads
of python modules.

Instead a prebuild image is first fetched
from dockerhub and afterwards used as cache to build.

Several adjustments have been necessary:
- Update the version of docker on travis (>0.13 is needed)
- Manually add the python modules in the Dockerfile.
  Otherwise the cache will not work as of the copied requrements.txt.
  Also fixed the version of the packages itself to get reliable builds.
- Add an automatic build on dockerhub

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>