### PR TITLE
Optimize Dockerfile and add ccache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.travis.yml
+data
+README.md
+requirements.txt
+ros

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 dist: trusty
 os: linux
 install: skip
+cache: 
+  - ccache
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
@@ -14,7 +16,7 @@ before_install:
 script:
   - docker pull kairosautomotive/carla-brain:latest 
   - docker build . --cache-from kairosautomotive/carla-brain:latest -t capstone
-  - docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
+  - docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ -v /home/travis/.ccache:/root/.ccache/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
 notifications:
   email:
       on_success: change

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,29 @@ LABEL maintainer="olala7846@gmail.com"
 
 # Install Dataspeed DBW https://goo.gl/KFSYi1 from binary
 # adding Dataspeed server to apt
-RUN sh -c 'echo "deb [ arch=amd64 ] http://packages.dataspeedinc.com/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-dataspeed-public.list'
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF6D3CDA
-RUN apt-get update
+RUN sh -c 'echo "deb [ arch=amd64 ] http://packages.dataspeedinc.com/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-dataspeed-public.list' && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF6D3CDA && \
+    sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
+RUN rosdep update && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ros-$ROS_DISTRO-dbw-mkz \
+                                               ros-$ROS_DISTRO-cv-bridge \
+                                               ros-$ROS_DISTRO-pcl-ros \
+                                               ros-$ROS_DISTRO-image-proc \
+                                               netbase \
+                                               python-pip \
+                                               ccache && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
 
-# setup rosdep
-RUN sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
-RUN rosdep update
-RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-dbw-mkz
-RUN apt-get upgrade -y
-# end installing Dataspeed DBW
-
-# install required ros dependencies
-RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-cv-bridge
-RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-pcl-ros
-RUN apt-get install -y --no-install-recommends ros-$ROS_DISTRO-image-proc
-
-# socket io
-RUN apt-get install -y --no-install-recommends netbase
+ENV PATH /usr/lib/ccache/:$PATH
 
 # install python packages
-RUN apt-get install -y --no-install-recommends python-pip
-RUN pip install --upgrade "pip==9.0.1"
-RUN pip install "Flask==0.12.2" "attrdict==2.0.0" "eventlet==0.21.0" "python-socketio==1.8.1" "numpy==1.13.3" "Pillow==4.3.0" "scipy==0.19.1" "keras==1.2.0" "tensorflow==1.0.0"
+RUN pip install --no-cache-dir --upgrade "pip==9.0.1" && \
+    pip install --no-cache-dir "Flask==0.12.2" "attrdict==2.0.0" "eventlet==0.21.0" "python-socketio==1.8.1" "numpy==1.13.3" "Pillow==4.3.0" "scipy==0.19.1" "keras==1.2.0" "tensorflow==1.0.0" && \
+    mkdir -p /capstone && mkdir -p /root/.ccache
 
-RUN mkdir /capstone
 VOLUME ["/capstone"]
 VOLUME ["/root/.ros/log/"]
+VOLUME ["/root/.ccache"]
 WORKDIR /capstone/ros

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Self Driving Car Engineer Nanodegree -- Capstone project
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/79ddbbe506054e43859247d9fd0b11b5)](https://www.codacy.com/app/Kairos-Automotive/carla-brain?utm_source=github.com&utm_medium=referral&utm_content=Kairos-Automotive/carla-brain&utm_campaign=badger) 
-[![Build Status](https://travis-ci.org/Kairos-AutomotAive/carla-braAin.svg?branch=master)](https://travis-ci.org/Kairos-Automotive/carla-brain) 
+[![Build Status](https://travis-ci.org/Kairos-AutomotAive/carla-brain.svg?branch=master)](https://travis-ci.org/Kairos-Automotive/carla-brain) 
 [![Docker Status](https://dockerbuildbadges.quelltext.eu/status.svg?organization=kairosautomotive&repository=carla-brain)](https://hub.docker.com/r/kairosautomotive/carla-brain/) 
 
 This is the project repo for the final project of the Udacity
@@ -50,6 +50,7 @@ or pull the latest docker container from dockerhub
 ```bash
 docker pull kairosautomotive/carla-brain:latest
 ```
+The prefered way for using containers is to use the prebuild.
 
 Run the docker file
 ```bash


### PR DESCRIPTION
The provided Dockerfiles contained a few items which
violate the best practices (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
In addition to fixing these issues, the size was
reduced by removing unnecessary caches and files.
Ccache was added into the image to enable faster builds
(especially for the travis builds). To store the ccache cache
outside the container the docker run command need to be extended with

-v /tmp/ccache:/root/.ccache/

Resolves #13

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>