### PR TITLE
Initial unit test for twist controller

### DIFF
--- a/ros/src/twist_controller/CMakeLists.txt
+++ b/ros/src/twist_controller/CMakeLists.txt
@@ -200,3 +200,7 @@ include_directories(
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_twist_controller.launch)
+endif()

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-
+import math
 import rospy
 from std_msgs.msg import Bool
 from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 from geometry_msgs.msg import TwistStamped
-import math
 
 from twist_controller import Controller
 
@@ -31,7 +30,9 @@ that we have created in the `__init__` function.
 
 '''
 
+
 class DBWNode(object):
+
     def __init__(self):
         rospy.init_node('dbw_node')
 
@@ -46,6 +47,8 @@ class DBWNode(object):
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
 
+        self.dbw_enabled = False
+
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
                                          SteeringCmd, queue_size=1)
         self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
@@ -57,22 +60,27 @@ class DBWNode(object):
         # self.controller = TwistController(<Arguments you wish to provide>)
 
         # TODO: Subscribe to all the topics you need to
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
 
         self.loop()
 
     def loop(self):
-        rate = rospy.Rate(50) # 50Hz
+        rate = rospy.Rate(50)  # 50Hz
         while not rospy.is_shutdown():
             # TODO: Get predicted throttle, brake, and steering using `twist_controller`
             # You should only publish the control commands if dbw is enabled
+            throttle, brake, steering = (1.0, 0.0, 0.0)
             # throttle, brake, steering = self.controller.control(<proposed linear velocity>,
             #                                                     <proposed angular velocity>,
             #                                                     <current linear velocity>,
             #                                                     <dbw status>,
             #                                                     <any other argument you need>)
-            # if <dbw is enabled>:
-            #   self.publish(throttle, brake, steer)
+            if self.dbw_enabled:
+                self.publish(throttle, brake, steering)
             rate.sleep()
+
+    def dbw_enabled_cb(self, msg):
+        self.dbw_enabled = msg.data
 
     def publish(self, throttle, brake, steer):
         tcmd = ThrottleCmd()

--- a/ros/src/twist_controller/package.xml
+++ b/ros/src/twist_controller/package.xml
@@ -45,6 +45,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>rostest</build_depend>
   <run_depend>dbw_mkz_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>

--- a/ros/src/twist_controller/test/test_twist_controller.launch
+++ b/ros/src/twist_controller/test/test_twist_controller.launch
@@ -1,0 +1,15 @@
+<launch>
+    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node">
+        <param name="vehicle_mass" value="1080." />
+        <param name="fuel_capacity" value="0." />
+        <param name="brake_deadband" value=".2" />
+        <param name="decel_limit" value="-5." />
+        <param name="accel_limit" value="1." />
+        <param name="wheel_radius" value="0.335" />
+        <param name="wheel_base" value="3" />
+        <param name="steer_ratio" value="14.8" />
+        <param name="max_lat_accel" value="3." />
+        <param name="max_steer_angle" value="8." />
+    </node>
+    <test test-name="test_twist_controller" pkg="twist_controller" type="test_twist_controller.py" time-limit="20.0" />
+</launch>

--- a/ros/src/twist_controller/test/test_twist_controller.py
+++ b/ros/src/twist_controller/test/test_twist_controller.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+"""
+Test cases
+"""
+import sys
+import time
+import threading
+import unittest
+import rospy
+import rostest
+from std_msgs.msg import Bool
+from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd
+
+PKG = 'waypoint_updater'
+NAME = 'test_waypoint_updater'
+
+
+class TestTwistController(unittest.TestCase):
+    """
+    A basic testcase for the twist controller.
+    It assumes that the twist controller will send in a constant rate
+    the control information.
+    When dbw_enabed is set to False, no control information shall be send
+    anymore as of user interaction.
+    """
+
+    def __init__(self, *args):
+        super(TestTwistController, self).__init__(*args)
+        self.success = False
+        self.failed_once = False
+        self.dbw_enabled = True
+        self.dbw_enabled_callback = self.dbw_enabled
+        self.lock = threading.Lock()
+
+    def callback(self, data):
+        """
+        Right now we're happy to get a lane
+        :param data: The callback information
+        """
+        with self.lock:
+            value = self.dbw_enabled_callback
+            if value:
+                self.success = False if self.failed_once else True
+            elif not self.dbw_enabled: # Last check if we already switched back.
+                self.failed_once = True
+                self.success = False
+
+        rospy.loginfo("%sxpected callback. dbw_enabled_callback %r, dbw_enabled %r, Failed before %r",
+                      "E" if value else "Une", value, self.dbw_enabled, self.failed_once)
+
+
+    def test_notify(self):
+        """
+        Test to receive a waypoint.
+        To trigger this, images needs to be published.
+        """
+        rospy.init_node(NAME, anonymous=True)
+        basepub = rospy.Publisher('/vehicle/dbw_enabled', Bool)
+        rospy.Subscriber('/vehicle/steering_cmd', SteeringCmd, self.callback)
+        rospy.Subscriber('/vehicle/throttle_cmd', ThrottleCmd, self.callback)
+        rospy.Subscriber('/vehicle/brake_cmd', BrakeCmd, self.callback)
+        count = 1
+        while not rospy.is_shutdown() and count < 10:
+            timeout_t = time.time() + 1.0  # 1 second
+            self.dbw_enabled = False if self.dbw_enabled else True
+            """
+            Immediately react if dbw is enabled
+            """
+            while time.time() < timeout_t:
+                basepub.publish(Bool(self.dbw_enabled))
+                rospy.logwarn("dbw_enabled: %r", self.dbw_enabled)
+                time.sleep(0.01)
+                """
+                Grace period if switching to dbw disabled
+                """
+                with self.lock:
+                    self.dbw_enabled_callback = self.dbw_enabled
+            count += 1
+        self.assert_(self.success, str(self.success))
+
+
+if __name__ == '__main__':
+    rostest.rosrun(PKG, NAME, TestTwistController, sys.argv)


### PR DESCRIPTION
Extended the twist controller to listen to /vehicle/dbw_enable
and to send some fake controll information if dbw is enabled.
The unit tests check if controll message are received if
dbw is enabled and also checks that no controll messages
are received if dbw is disabled.

Fixes #18 

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>