### PR TITLE
Styx: workaround for socket.timeout and faster shutdown

### DIFF
--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
+import sys
+import threading
+import os
+import signal
 import socketio
 import eventlet
 import eventlet.wsgi
 import time
 from flask import Flask, render_template
+import rospy
 
 from bridge import Bridge
 from conf import conf
@@ -14,17 +19,21 @@ app = Flask(__name__)
 msgs = []
 
 dbw_enable = False
+rospy.init_node('styx_server')
+
 
 @sio.on('connect')
 def connect(sid, environ):
     print("connect ", sid)
 
+
 def send(topic, data):
     s = 1
     msgs.append((topic, data))
-    #sio.emit(topic, data=json.dumps(data), skip_sid=True)
+    # sio.emit(topic, data=json.dumps(data), skip_sid=True)
 
 bridge = Bridge(conf, send)
+
 
 @sio.on('telemetry')
 def telemetry(sid, data):
@@ -37,30 +46,48 @@ def telemetry(sid, data):
         topic, data = msgs.pop(0)
         sio.emit(topic, data=data, skip_sid=True)
 
+
 @sio.on('control')
 def control(sid, data):
     bridge.publish_controls(data)
+
 
 @sio.on('obstacle')
 def obstacle(sid, data):
     bridge.publish_obstacles(data)
 
+
 @sio.on('lidar')
 def obstacle(sid, data):
     bridge.publish_lidar(data)
+
 
 @sio.on('trafficlights')
 def trafficlights(sid, data):
     bridge.publish_traffic(data)
 
+
 @sio.on('image')
 def image(sid, data):
     bridge.publish_camera(data)
 
+
+def spinning_worker():
+    rospy.spin()
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
 if __name__ == '__main__':
+    t = threading.Thread(target=spinning_worker)
+    t.start()
 
     # wrap Flask application with engineio's middleware
-    app = socketio.Middleware(sio, app)
+    app.wsgi_app = socketio.Middleware(sio, app.wsgi_app)
 
     # deploy as an eventlet WSGI server
-    eventlet.wsgi.server(eventlet.listen(('', 4567)), app)
+    while not rospy.is_shutdown():
+        try:
+            eventlet.wsgi.server(eventlet.listen(('', 4567)), app)
+        except:
+            # Until https://github.com/eventlet/eventlet/issues/222 is solved
+            rospy.logerr("Unexpected error: %r", sys.exc_info()[0])


### PR DESCRIPTION
A wrong implementation in eventlet let the server die
after some time if there was no initial connection.
It was not solved yet (https://github.com/eventlet/eventlet/issues/222).
Retrigger the server after this exception.

Ros and eventlet's are not playing too nice together
when it is time to shutdown the service.
Trigger a sigkill to enforce this.

Few pylint cleanups.

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>