### PR TITLE
Fix communication issues w/simulator on mac os.

### DIFF
--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -14,7 +14,9 @@ import rospy
 from bridge import Bridge
 from conf import conf
 
-sio = socketio.Server()
+eventlet.monkey_patch()
+
+sio = socketio.Server(async_mode='eventlet')
 app = Flask(__name__)
 msgs = []
 


### PR DESCRIPTION
Using explicitly eventlet for async operations within socketio
seems to fix communcation issues with simulator.

Source for fix: https://discussions.udacity.com/t/car-freezes-in-simulator-solved/363942/12?u=victor_guerra_986699