### PR TITLE
Add argument to select how socketio and eventlet are initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ catkin_make
 source devel/setup.sh
 roslaunch launch/styx.launch
 ```
+If the connection of the simulator is not working as expected it 
+is possible to lauch with the workaround described in the [discussion](https://discussions.udacity.com/t/car-freezes-in-simulator-solved/363942/12?u=victor_guerra_986699).
+
+```bash
+roslaunch launch/styx.launch monkey_patch:=true
+```
 
 4. Run the simulator
 

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <launch>
+    <arg name="monkey_patch" default="false" />
+    <param name="do_monkey_patch" type="bool" value="$(arg monkey_patch)"/>
+
     <!-- Simulator Bridge -->
     <include file="$(find styx)/launch/server.launch" />
 

--- a/ros/src/styx/launch/server.launch
+++ b/ros/src/styx/launch/server.launch
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="styx" type="server.py" name="styx_server" />
-
+    <node pkg="styx" type="server.py" name="styx_server"/>
     <!--Launch simulator -->
     <node name="unity_simulator" pkg="styx" type="unity_simulator_launcher.sh" output="screen"/>
 </launch>

--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -14,13 +14,22 @@ import rospy
 from bridge import Bridge
 from conf import conf
 
-sio = socketio.Server()
-app = Flask(__name__)
-msgs = []
+
 
 dbw_enable = False
+MONKEY_PATCH = rospy.get_param('do_monkey_patch', False)
+
+rospy.logwarn("monkey_patch: %r", MONKEY_PATCH)
+if not MONKEY_PATCH:
+    sio = socketio.Server()
+else:
+    eventlet.monkey_patch()
+    sio = socketio.Server(async_mode='eventlet')
+
 rospy.init_node('styx_server')
 
+app = Flask(__name__)
+msgs = []
 
 @sio.on('connect')
 def connect(sid, environ):


### PR DESCRIPTION
By default the regular initialization will be used.
If the argument monkey_path:=true is provided, the
initialization mentioned in https://discussions.udacity.com/t/car-freezes-in-simulator-solved/363942/12?u=victor_guerra_986699
will be used instead.

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>