### PR TITLE
adding environment variable to launch files

### DIFF
--- a/ros/launch/site.launch
+++ b/ros/launch/site.launch
@@ -26,5 +26,5 @@
     <include file="$(find camera_info_publisher)/launch/camera_info_publisher.launch"/>
 
     <!--Set environment variable -->
-    <param name="current_env" value="simulator" />
+    <param name="current_env" value="live" />
 </launch>

--- a/ros/launch/site.launch
+++ b/ros/launch/site.launch
@@ -24,4 +24,7 @@
 
     <!--Camera Info Publisher -->
     <include file="$(find camera_info_publisher)/launch/camera_info_publisher.launch"/>
+
+    <!--Set environment variable -->
+    <param name="current_env" value="simulator" />
 </launch>

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -26,7 +26,7 @@
     <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
 
     <!--Set environment variable -->
-    <param name="current_env" value="live" />
+    <param name="current_env" value="simulator" />
 
 
 </launch>

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -24,4 +24,9 @@
 
     <!--Traffic Light Locations and Camera Config -->
     <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+
+    <!--Set environment variable -->
+    <param name="current_env" value="live" />
+
+
 </launch>


### PR DESCRIPTION
Tiny change - I've added a variable `current_env` to the launch files which takes values `live` or `simulator`. Should be a neat way of making sure all the variables / models we load are consistently set for the right environment. 