### PR TITLE
tl_detector: When new waypoints are set, replace the current one's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ unzip traffic_light_bag_files.zip
 rosbag play -l traffic_light_bag_files/loop_with_traffic_light.bag
 ```
 
+To disable specific topics from the bag they can either be 
+[filtered](https://answers.ros.org/question/228676/exclude-some-topics-from-rosbag-play/) 
+or the topics can be renamed during playback:
+
+```bash
+rosbag play -l udacity_succesful_light_detection.bag /traffic_waypoint:=/traffic_waypoint_null /final_waypoints:=/final_waypoints_null /base_waypoints:=/base_waypoints_null /vehicle/steering_cmd:=/vehicle/steering_cmd_null 
+
+```
+
 4. Launch your project in site mode
 ```bash
 cd carla-brain/ros

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -68,12 +68,15 @@ class TLDetector(object):
         self.pose = msg
 
     def waypoints_cb(self, waypoints):
-        self.waypoints = waypoints
+        waypoints_np = np.array([])
 
         for point in waypoints.waypoints:
             x_coord = point.pose.pose.position.x
             y_coord = point.pose.pose.position.y
-            self.waypoints_np = np.append(self.waypoints_np, complex(x_coord, y_coord))
+            waypoints_np = np.append(waypoints_np, complex(x_coord, y_coord))
+
+        self.waypoints = waypoints
+        self.waypoints_np = waypoints_np
 
         rospy.logwarn("Waypoints updated to "+ str(len(self.waypoints_np))+ " elements")
 
@@ -97,6 +100,7 @@ class TLDetector(object):
         """
         self.has_image = True
         self.camera_image = msg
+
         light_wp, state = self.process_traffic_lights()
 
         '''
@@ -115,6 +119,7 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(light_wp))
         else:
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
+
         self.state_count += 1
 
     def get_closest_waypoint(self, pose):


### PR DESCRIPTION
An update of /base_waypoints always updates the complete waypoints.
Reflect this in the callback.
Add information how to disable certain topics in the README.md.
Otherwise the bad topic and the generated content for the topic
will be published at the same time.

Fixes #45

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>