### PR TITLE
Remove the security warnings from codacity static code check.

### DIFF
--- a/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
+++ b/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
@@ -38,7 +38,7 @@ def yaml_to_CameraInfo(calib_yaml):
         data
     """
     # Load data from file
-    calib_data = yaml.load(calib_yaml)
+    calib_data = yaml.safe_load(calib_yaml)
     # Parse
     camera_info_msg = CameraInfo()
     camera_info_msg.width = calib_data["image_width"]

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -46,7 +46,7 @@ class TLDetector(object):
         self.base_waypoints_np = np.array([])
         rospy.Subscriber('/base_waypoints', Lane, self.base_waypoints_cb, queue_size=1)
 
-        self.tl_config = yaml.load(rospy.get_param("/traffic_light_config"))
+        self.tl_config = yaml.safe_load(rospy.get_param("/traffic_light_config"))
 
         self.car_direction = 1
         self.last_car_wp_idx = None


### PR DESCRIPTION
Since the yaml files don't seem to contain specific python objects
but just lists and integers, the use of safe_load should work.

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>