### PR TITLE
Propagate unit test errors to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - docker pull kairosautomotive/carla-brain:latest 
   - docker build . --cache-from kairosautomotive/carla-brain:latest -t capstone
   - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ -v /home/travis/.ccache:/root/.ccache/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
-  - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it --workdir /capstone/ros kairosautomotive/carla-brain /bin/bash -c "source devel/setup.bash && /opt/ros/kinetic/bin/catkin_make run_tests" 
+  - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it --workdir /capstone/ros kairosautomotive/carla-brain /bin/bash -c "source devel/setup.bash && /opt/ros/kinetic/bin/catkin_make run_tests; exit $?" 
 notifications:
   email:
       on_success: change


### PR DESCRIPTION
Failing unit tests have been reported as successful 
to travis. The change will ensure that the docker
running a shell running the unit test will
propagate the error down to travis.

Fixes #78