### PR TITLE
Check status of unit test based on files and not exit status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - docker pull kairosautomotive/carla-brain:latest 
   - docker build . --cache-from kairosautomotive/carla-brain:latest -t capstone
   - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ -v /home/travis/.ccache:/root/.ccache/ --rm --workdir /capstone/ros capstone  /opt/ros/kinetic/bin/catkin_make 
-  - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it --workdir /capstone/ros kairosautomotive/carla-brain /bin/bash -c "source devel/setup.bash && /opt/ros/kinetic/bin/catkin_make run_tests; exit $?" 
+  - docker run -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it --workdir /capstone/ros kairosautomotive/carla-brain /bin/bash -c "source devel/setup.bash && /opt/ros/kinetic/bin/catkin_make run_tests; if test \$(grep -r \"errors=\\\"0\\\" failures=\\\"0\\\"\"  build/test_results/ | wc -l) -eq \$(find build/test_results/ -type f | wc -l); then exit 0; else exit 1; fi;"
 notifications:
   email:
       on_success: change


### PR DESCRIPTION
The behavior of catkin_make run_tests differs locally
from the travis environment. While on travis it always
exits with 1 a successful local build exists with 0.
To fix this the passed/failed status will be returned
by a comparition of the unit test files. If all files
do contain no errors, the test will pass otherwise it will
fail.

With the next iteration the script has to be seperated
into an own file.

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>